### PR TITLE
Clean up machine init interface and sync CLI initial state

### DIFF
--- a/Podman Desktop.xcodeproj/project.pbxproj
+++ b/Podman Desktop.xcodeproj/project.pbxproj
@@ -13,12 +13,13 @@
 		1464F9E827544393006A6813 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1464F9E727544393006A6813 /* Preview Assets.xcassets */; };
 		1464FA0F2758ABB2006A6813 /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1464FA0E2758ABB2006A6813 /* HeaderView.swift */; };
 		1478D409278E2820004DF7BC /* MachineInitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1478D408278E2820004DF7BC /* MachineInitView.swift */; };
-		14912A86275E9C2400ACF55D /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14912A85275E9C2400ACF55D /* File.swift */; };
-		14912A88275EBFE200ACF55D /* ModelData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14912A87275EBFE200ACF55D /* ModelData.swift */; };
+		14912A86275E9C2400ACF55D /* Machine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14912A85275E9C2400ACF55D /* Machine.swift */; };
+		14912A88275EBFE200ACF55D /* Shell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14912A87275EBFE200ACF55D /* Shell.swift */; };
 		14912A8C2760F3F200ACF55D /* BodyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14912A8B2760F3F200ACF55D /* BodyView.swift */; };
 		14A0A7442761ECAC0063F087 /* MenuBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A0A7432761ECAC0063F087 /* MenuBar.swift */; };
 		14A0A7462761ED1D0063F087 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A0A7452761ED1D0063F087 /* MenuBarController.swift */; };
 		14A0A748276250430063F087 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A0A747276250430063F087 /* SettingsView.swift */; };
+		14A5DF0A2790A49C0051B9AE /* MachineSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A5DF092790A49C0051B9AE /* MachineSelectView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,12 +31,13 @@
 		1464F9E927544393006A6813 /* Podman_Desktop.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Podman_Desktop.entitlements; sourceTree = "<group>"; };
 		1464FA0E2758ABB2006A6813 /* HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
 		1478D408278E2820004DF7BC /* MachineInitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachineInitView.swift; sourceTree = "<group>"; };
-		14912A85275E9C2400ACF55D /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
-		14912A87275EBFE200ACF55D /* ModelData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelData.swift; sourceTree = "<group>"; };
+		14912A85275E9C2400ACF55D /* Machine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Machine.swift; sourceTree = "<group>"; };
+		14912A87275EBFE200ACF55D /* Shell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shell.swift; sourceTree = "<group>"; };
 		14912A8B2760F3F200ACF55D /* BodyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyView.swift; sourceTree = "<group>"; };
 		14A0A7432761ECAC0063F087 /* MenuBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBar.swift; sourceTree = "<group>"; };
 		14A0A7452761ED1D0063F087 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
 		14A0A747276250430063F087 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		14A5DF092790A49C0051B9AE /* MachineSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachineSelectView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -92,6 +94,7 @@
 				1464F9E227544392006A6813 /* ContentView.swift */,
 				14A0A747276250430063F087 /* SettingsView.swift */,
 				1478D408278E2820004DF7BC /* MachineInitView.swift */,
+				14A5DF092790A49C0051B9AE /* MachineSelectView.swift */,
 				1464FA0E2758ABB2006A6813 /* HeaderView.swift */,
 				14912A8B2760F3F200ACF55D /* BodyView.swift */,
 				14A0A7432761ECAC0063F087 /* MenuBar.swift */,
@@ -102,8 +105,8 @@
 		14912A84275E632500ACF55D /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				14912A85275E9C2400ACF55D /* File.swift */,
-				14912A87275EBFE200ACF55D /* ModelData.swift */,
+				14912A85275E9C2400ACF55D /* Machine.swift */,
+				14912A87275EBFE200ACF55D /* Shell.swift */,
 				14A0A7452761ED1D0063F087 /* MenuBarController.swift */,
 			);
 			path = Models;
@@ -185,8 +188,9 @@
 				14A0A7442761ECAC0063F087 /* MenuBar.swift in Sources */,
 				1464F9E327544392006A6813 /* ContentView.swift in Sources */,
 				14A0A748276250430063F087 /* SettingsView.swift in Sources */,
-				14912A86275E9C2400ACF55D /* File.swift in Sources */,
-				14912A88275EBFE200ACF55D /* ModelData.swift in Sources */,
+				14912A86275E9C2400ACF55D /* Machine.swift in Sources */,
+				14A5DF0A2790A49C0051B9AE /* MachineSelectView.swift in Sources */,
+				14912A88275EBFE200ACF55D /* Shell.swift in Sources */,
 				1464FA0F2758ABB2006A6813 /* HeaderView.swift in Sources */,
 				1464F9E127544392006A6813 /* Podman_DesktopApp.swift in Sources */,
 			);

--- a/Podman Desktop/Models/Machine.swift
+++ b/Podman Desktop/Models/Machine.swift
@@ -53,14 +53,29 @@ class AllMachines: ObservableObject{
             
         }
         catch {
-            print("asdsad")
             print("\(error)") // need to write custom errors
         }
         
         self.lst=jsons
-        print(lst)
-        let t = type(of: lst[0].name)
-            print("of type '\(t)'")
+    }
+    func getRunning() -> (isRunning: Bool, machineInfo: Machine?){
+        let getRunning = AllMachines()
+        for mach in getRunning.lst{
+            if mach.running{
+                return(true, mach)
+            }
+        }
+        return (false, nil)
+    }
+        
+    func getCLIDefault() -> Machine?{
+        let getRunning = AllMachines()
+        for mach in getRunning.lst{
+            if mach.dflt{
+                return(mach)
+            }
+        }
+        return(nil)
     }
 }
 
@@ -81,7 +96,6 @@ class DefaultMachine: ObservableObject {
     init(){
         do {
             let output = try shell(launchPath: "/usr/bin/env", arguments: ["podman","machine", "list", "--format", "json"])
-            print(output.1)
             let jsonData = output.1.data(using: .utf8)!
             jsons = try! JSONDecoder().decode([Machine].self, from: jsonData)
 
@@ -89,7 +103,6 @@ class DefaultMachine: ObservableObject {
             
         }
         catch {
-            print("asdsad")
             print("\(error)") //handle or silence the error here
         }
         self.name = jsons[0].name
@@ -103,4 +116,37 @@ class DefaultMachine: ObservableObject {
         self.memory=jsons[0].memory
         self.disksize=jsons[0].disksize
     }
+}
+
+class NewMachine: ObservableObject {
+    @Published var name: String
+    @Published var ignitionPath: String
+    @Published var imagePath: String
+    @Published var cpus: Int
+    @Published var memory: Int
+    @Published var disksize: Int
+    
+    var jsons = [Machine]()
+    
+    init(){
+        self.name = "New Machine"
+        self.ignitionPath=""
+        self.imagePath="next"
+        self.cpus=1
+        self.memory=2040
+        self.disksize=10
+    }
+    func validate(){
+        
+    }
+    func create() throws {
+        do {
+            try shell(launchPath: "/usr/bin/env", arguments: ["podman","machine", "init", "--cpus", String(cpus), "--memory", String(memory), "--disk-size", String(disksize), "--ignition-path", ignitionPath, "--image-path", imagePath, name])
+            
+        }
+        catch {
+            print("\(error)") // need to write custom errors
+        }
+    }
+}
 

--- a/Podman Desktop/Models/Shell.swift
+++ b/Podman Desktop/Models/Shell.swift
@@ -7,30 +7,6 @@
 
 import Foundation
 
-var machines: [Machine] = load("landmarkData.json")
-
-func load<T: Decodable>(_ filename: String) -> T {
-    let data: Data
-
-    guard let file = Bundle.main.url(forResource: filename, withExtension: nil)
-    else {
-        fatalError("Couldn't find \(filename) in main bundle.")
-    }
-
-    do {
-        data = try Data(contentsOf: file)
-    } catch {
-        fatalError("Couldn't load \(filename) from main bundle:\n\(error)")
-    }
-
-    do {
-        let decoder = JSONDecoder()
-        return try decoder.decode(T.self, from: data)
-    } catch {
-        fatalError("Couldn't parse \(filename) as \(T.self):\n\(error)")
-    }
-}
-
 
 func shell(launchPath: String, arguments: [String]) throws ->  (Int32, String){
     var str=""
@@ -41,7 +17,7 @@ func shell(launchPath: String, arguments: [String]) throws ->  (Int32, String){
     process.standardOutput = pipe
     process.standardError = pipe
     var environment =  ProcessInfo.processInfo.environment
-        environment["PATH"] = (environment["PATH"] ?? "")+":/opt/homebrew/bin/podman:/usr/local/bin/podman"
+        environment["PATH"] = (environment["PATH"] ?? "")+":/opt/homebrew/bin/:/usr/local/bin/"
         process.environment = environment
     do {
         try process.run()

--- a/Podman Desktop/Podman_DesktopApp.swift
+++ b/Podman Desktop/Podman_DesktopApp.swift
@@ -10,6 +10,12 @@ import SwiftUI
 @main
 struct Podman_DesktopApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    init() {
+            if !UserDefaults.standard.bool(forKey: "didLaunchBefore") {
+                UserDefaults.standard.set(true, forKey: "didLaunchBefore")
+            }
+    }
+        
     var body: some Scene {
         Settings {
             EmptyView()

--- a/Podman Desktop/Views/ContentView.swift
+++ b/Podman Desktop/Views/ContentView.swift
@@ -13,23 +13,25 @@ struct ContentView: View {
     var machineOn = MachineOn()
     @State private var settings = false
     var body: some View {
-        VStack{
+        VStack(spacing: 0){
             HeaderView(settings: $settings)
                 .frame(height: 70)
                 .environmentObject(machineOn)
 
-            
-//            if self.settings{
-//                SettingsView()
-//                    .frame(height: 300)
-//            }else{
-//                BodyView()
-//            }
-//            SettingsView()
+//            AnotherView()
+            if self.settings{
+                SettingsView(settings: $settings)
+                    .frame(height: 300)
+                Spacer()
+            }else{
+                BodyView()
+            }
+//            SettingsView(settings: $settings)
 //                .frame(height: 300)
 //            MachineInitView()
-            BodyView()
             Spacer()
+//            BodyView()
+//            Spacer()
         }
         .ignoresSafeArea()
 
@@ -44,8 +46,15 @@ class MachineOn: ObservableObject {
     @Published var isOn: Bool
     @Published var displayString: String
     init(){
-        self.isOn = false
-        self.displayString="not running"
+        let machs = AllMachines()
+        let isRunning = machs.getRunning().isRunning
+        if isRunning{
+            self.isOn = true
+            self.displayString="running"
+        } else {
+            self.isOn = false
+            self.displayString="not running"
+        }
     }
     
 }

--- a/Podman Desktop/Views/HeaderView.swift
+++ b/Podman Desktop/Views/HeaderView.swift
@@ -21,7 +21,7 @@ struct HeaderView: View {
                     .frame(width: 200)
                 MachineControls(settings: $settings)
             }
-           }
+        }
     }
 }
 
@@ -36,7 +36,6 @@ struct MachineControls: View{
             Spacer()
             Text ("Podman is:")
                 .foregroundColor(.gray)
-//            ProgressView()
 
             Text(machineOn.displayString)
                     .foregroundColor(.white)

--- a/Podman Desktop/Views/MachineInitView.swift
+++ b/Podman Desktop/Views/MachineInitView.swift
@@ -8,61 +8,210 @@
 import SwiftUI
 
 struct MachineInitView: View {
-    @State private var name: String = ""
-    @State private var vmimage: String = ""
-    @State private var cpus: String = ""
-    @State private var memory: String = ""
-    @State private var disksize: String = ""
-    @State private var ignition: String = ""
+    
+    @ObservedObject var newMachine = NewMachine()
+    var streams = ["stable", "testing", "next"]
+    @State private var vmImg = "fcos"
+    @State var customVM = false
+    @State var customIgn = false
+    @State private var ignFile = ""
+    @State var imgFile = ""
+    
+    var memoryToInt: Binding<Double>{
+            Binding<Double>(get: {
+                //returns the score as a Double
+                return Double(newMachine.memory)
+            }, set: {
+                //rounds the double to an Int
+                newMachine.memory = Int($0)
+            })
+        }
+    
+    var diskToInt: Binding<Double>{
+            Binding<Double>(get: {
+                //returns the score as a Double
+                return Double(newMachine.disksize)
+            }, set: {
+                //rounds the double to an Int
+                newMachine.disksize = Int($0)
+            })
+        }
 
     var body: some View {
-        VStack{
-            TextField(
-                "VM Name",
-                text: $name
-            )
-//            .onSubmit {
-//                validate(name: uname)
-//            }
-            TextField(
-                "VM image",
-                text: $vmimage
-            )
-            TextField(
-                "CPUs",
-                text: $cpus
-            )
-            TextField(
-                "RAM",
-                text: $memory
-            )
-            TextField(
-                "Disk size",
-                text: $disksize
-            )
-            TextField(
-                "Ignition File",
-                text: $ignition
-            )
-            Button("Submit") {
-                // need to validate data, make sure no fields are emptyhere
-                
-                do {
-                    try shell(launchPath: "/usr/bin/env", arguments: ["podman","machine", "init", "--cpus", cpus, "--memory", memory, "--disk-size", disksize, "--ignition-path", ignition, "--image-path", vmimage, name])
-                    
+        Group{
+            ZStack{
+                Color.white
+                HStack{
+                    Text("Create a new VM")
+                        .multilineTextAlignment(.leading)
+                        .font(.title2)
                 }
-                catch {
-                    print("asdsad")
-                    print("\(error)") // need to write custom errors
+                .padding(EdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20))
+            }
+            .padding(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+            .frame(height: 50, alignment: .leading)
+        }
+        Spacer()
+        VStack{
+            HStack{
+                Text("Machine Name")
+                    .frame(width:100)
+                TextField(
+                    "VM Name",
+                    text: $newMachine.name
+                )
+            }
+            
+            HStack(alignment: .firstTextBaseline){
+                Text("VM OS")
+                    .frame(width:100)
+
+                    Picker("", selection: $vmImg) { // <2>
+                        HStack{
+                            Text("Fedora CoreOS") // <3>
+                            Picker("",selection: $newMachine.imagePath) {
+                                               ForEach(streams, id: \.self) {
+                                                   Text($0)
+                                               }
+                                           }
+                            .disabled(vmImg != "fcos")
+                                           .pickerStyle(SegmentedPickerStyle())
+                        }.tag("fcos")
+                        
+                        HStack{
+                            Button("Custom Image"){
+                                let panel = NSOpenPanel()
+                                panel.allowsMultipleSelection = false
+                                panel.canChooseDirectories = false
+                                if panel.runModal() == .OK {
+                                   self.imgFile = panel.url?.path ?? "select"
+                                }
+                            }
+                            .disabled(vmImg != "custom")
+                            Text(imgFile)
+                                .frame(width: 250, height: 10)
+                                .truncationMode(.head)
+                        }.tag("custom")
+                    }
+                    .pickerStyle(RadioGroupPickerStyle())
+            }
+            
+            HStack{
+                Text("CPUs")
+                    .frame(width:100)
+                TextField(
+                    "CPUs",
+                    value: $newMachine.cpus,
+                    format: .number
+                )
+                    .frame(width: 25)
+                Stepper("",value: $newMachine.cpus)
+                Spacer()
+            }
+            HStack{
+                Text("RAM")
+                    .frame(width:100)
+                TextField(
+                    "Memory",
+                    value: $newMachine.memory,
+                    format: .number
+                )
+                    .frame(width: 65)
+                    
+                Text("MB")
+                Slider.ln(value: memoryToInt, in: 1 ... 65536)
+            }
+            
+            HStack{
+                Text("Disk size")
+                    .frame(width:100)
+                TextField(
+                    "Disk size",
+                    value: $newMachine.disksize,
+                    format: .number
+                )
+                    .frame(width: 65)
+                Text("GB")
+                Slider.ln(value: diskToInt, in: 16 ... 2048)
+            }
+            
+            HStack{
+                Text("Ignition Path")
+                    .frame(width:100)
+                    Picker("", selection: $customIgn) { // <2>
+                            Text("Generate Default") // <3>
+                                .tag(false)
+                        HStack{
+                            Button("Upload Custom Ignition"){
+                                let panel = NSOpenPanel()
+                                panel.allowsMultipleSelection = false
+                                panel.canChooseDirectories = false
+                                if panel.runModal() == .OK {
+                                   self.ignFile = panel.url?.path ?? "select"
+                                }
+                            }
+                            .disabled(!customIgn)
+                            Text(ignFile)
+                                .frame(width: 200, height: 10)
+                                .truncationMode(.head)
+                        }.tag(true)
+                    }
+                    .pickerStyle(RadioGroupPickerStyle())
+            }
+            HStack{
+                Button("Cancel"){
+                    print("go back")
+                }
+                Button("Submit") {
+                               // need to validate data, make sure no fields are emptyhere
+                    do{
+                        try newMachine.create()
+                    } catch {
+                        print("error")
+                    }
                 }
             }
+            .padding(40)
         }
-}
+        .padding(EdgeInsets(top: 30, leading: 0, bottom: 0, trailing: 0))
+        .frame(width: 500)
+        Spacer()
+    }
 }
 
 
 struct MachineInitView_Previews: PreviewProvider {
     static var previews: some View {
         MachineInitView()
+    }
+}
+
+
+extension Binding where Value == Double {
+    func logarithmic(base: Double = 2) -> Binding<Double> {
+        Binding(
+            get: {
+                log2(self.wrappedValue) / log2(base)
+            },
+            set: { (newValue) in
+                self.wrappedValue = pow(base, newValue)
+            }
+        )
+    }
+}
+
+extension Slider where Label == EmptyView, ValueLabel == EmptyView {
+
+    static func ln(
+        value: Binding<Double>,
+        in range: ClosedRange<Double>,
+        onEditingChanged: @escaping (Bool) -> Void = { _ in }
+    ) -> Slider {
+        return self.init(
+            value: value.logarithmic(),
+            in: log2(range.lowerBound) ... log2(range.upperBound),
+            step: 1,
+            onEditingChanged: onEditingChanged
+        )
     }
 }

--- a/Podman Desktop/Views/MachineSelectView.swift
+++ b/Podman Desktop/Views/MachineSelectView.swift
@@ -1,0 +1,27 @@
+//
+//  MachineInitView.swift
+//  Podman Desktop
+//
+//  Created by Ashley Cui on 12/18/22.
+//
+
+import SwiftUI
+
+struct MachineSelectView: View {
+    @ObservedObject var allMachines = AllMachines()
+    @State private var chosenVM = ""
+    var body: some View {
+        Picker("VM", selection: $chosenVM){
+            ForEach(allMachines.lst, id: \.self) { item in
+                Text(item.name)
+        }
+    }
+        Text("Selected: \(chosenVM)")
+    }
+}
+
+struct MachineSelectView_Previews: PreviewProvider {
+    static var previews: some View {
+        MachineSelectView()
+    }
+}

--- a/Podman Desktop/Views/SettingsView.swift
+++ b/Podman Desktop/Views/SettingsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @ObservedObject var currMachine = DefaultMachine()
-
+    @Binding var settings: Bool
     
     var body: some View {
         VStack {
@@ -21,6 +21,19 @@ struct SettingsView: View {
                             .multilineTextAlignment(.leading)
                             .font(.title2)
                         Spacer()
+                        Button(action: {
+                            self.settings.toggle()
+                                    }){
+                                        Image(systemName: "xmark")
+                                            .resizable()
+                                            .scaledToFit()
+                                            .foregroundColor(.gray)
+                                            .frame(width: 20, height: 20)
+                                    }
+                                    .padding(.trailing)
+                                    .opacity(1)
+                                    .buttonStyle(PlainButtonStyle())
+
                     }
                     .padding(EdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20))
                 }
@@ -100,8 +113,9 @@ struct SettingsView: View {
     }
 }
 
-struct SettingsView_Previews: PreviewProvider {
-    static var previews: some View {
-        SettingsView()
-    }
-}
+//struct SettingsView_Previews: PreviewProvider {
+//    @Binding var settings: Bool
+//    static var previews: some View {
+//        SettingsView(settings: settings)
+//    }
+//}


### PR DESCRIPTION
Machine init interface now has intuitive inputs for machine init
Podman-desktop will also detect if the machine has been started/stopped from not the GUI (ie, someone uses literally `podman machine start/stop`) and use that to initialize the state of the GUI

Signed-off-by: Ashley Cui <acui@redhat.com>