### PR TITLE
Refactor state handling

### DIFF
--- a/Podman Desktop.xcodeproj/project.pbxproj
+++ b/Podman Desktop.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1425F9D527A7E3E200057FDD /* ViewRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1425F9D427A7E3E200057FDD /* ViewRouter.swift */; };
 		1464F9E127544392006A6813 /* Podman_DesktopApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1464F9E027544392006A6813 /* Podman_DesktopApp.swift */; };
 		1464F9E327544392006A6813 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1464F9E227544392006A6813 /* ContentView.swift */; };
 		1464F9E527544393006A6813 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1464F9E427544393006A6813 /* Assets.xcassets */; };
@@ -20,9 +21,11 @@
 		14A0A7462761ED1D0063F087 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A0A7452761ED1D0063F087 /* MenuBarController.swift */; };
 		14A0A748276250430063F087 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A0A747276250430063F087 /* SettingsView.swift */; };
 		14A5DF0A2790A49C0051B9AE /* MachineSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A5DF092790A49C0051B9AE /* MachineSelectView.swift */; };
+		14B5E91027A0484800D756F4 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B5E90F27A0484800D756F4 /* Errors.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1425F9D427A7E3E200057FDD /* ViewRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewRouter.swift; sourceTree = "<group>"; };
 		1464F9DD27544392006A6813 /* Podman Desktop.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Podman Desktop.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1464F9E027544392006A6813 /* Podman_DesktopApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Podman_DesktopApp.swift; sourceTree = "<group>"; };
 		1464F9E227544392006A6813 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -38,6 +41,7 @@
 		14A0A7452761ED1D0063F087 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
 		14A0A747276250430063F087 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		14A5DF092790A49C0051B9AE /* MachineSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachineSelectView.swift; sourceTree = "<group>"; };
+		14B5E90F27A0484800D756F4 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,7 +110,9 @@
 			isa = PBXGroup;
 			children = (
 				14912A85275E9C2400ACF55D /* Machine.swift */,
+				1425F9D427A7E3E200057FDD /* ViewRouter.swift */,
 				14912A87275EBFE200ACF55D /* Shell.swift */,
+				14B5E90F27A0484800D756F4 /* Errors.swift */,
 				14A0A7452761ED1D0063F087 /* MenuBarController.swift */,
 			);
 			path = Models;
@@ -183,9 +189,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				14A0A7462761ED1D0063F087 /* MenuBarController.swift in Sources */,
+				1425F9D527A7E3E200057FDD /* ViewRouter.swift in Sources */,
 				14912A8C2760F3F200ACF55D /* BodyView.swift in Sources */,
 				1478D409278E2820004DF7BC /* MachineInitView.swift in Sources */,
 				14A0A7442761ECAC0063F087 /* MenuBar.swift in Sources */,
+				14B5E91027A0484800D756F4 /* Errors.swift in Sources */,
 				1464F9E327544392006A6813 /* ContentView.swift in Sources */,
 				14A0A748276250430063F087 /* SettingsView.swift in Sources */,
 				14912A86275E9C2400ACF55D /* Machine.swift in Sources */,

--- a/Podman Desktop/Models/Errors.swift
+++ b/Podman Desktop/Models/Errors.swift
@@ -1,0 +1,60 @@
+//
+//  Errors.swift
+//  Podman Desktop
+//
+//  Created by Ashley Cui on 1/25/22.
+//
+
+import Foundation
+
+
+enum MachineStartError: Error {
+    case machineNotExist
+    case alreadyRunning
+    case genericError
+}
+
+
+enum MachineInitError: Error {
+    case invalidCPUs
+    case invalidIgnition
+    case invalidImage
+    case invalidDisk
+    case invalidMemory
+    case machineExists
+    case genericError
+}
+
+enum MachineStop: Error {
+    case genericError
+}
+
+func parseMachineStart(message: String) -> Error{
+    switch message {
+    case let str where str.contains("VM does not exist"):
+        return MachineStartError.machineNotExist
+    case let str where str.contains("VM already running"):
+        return MachineStartError.alreadyRunning
+    default:
+        return MachineStartError.genericError
+    }
+}
+
+func parseMachineInitError(message: String) -> Error{
+    switch message {
+    case let str where str.contains("VM already existst"):
+        return MachineInitError.machineExists
+    case let str where str.contains("cpus"):
+        return MachineInitError.invalidCPUs
+    case let str where str.contains("disk-size"):
+        return MachineInitError.invalidDisk
+    case let str where str.contains("ignition-path"):
+        return MachineInitError.invalidIgnition
+    case let str where str.contains("image-path"):
+        return MachineInitError.invalidImage
+    case let str where str.contains("memory"):
+        return MachineInitError.invalidMemory
+    default:
+        return MachineStartError.genericError
+    }
+}

--- a/Podman Desktop/Models/ViewRouter.swift
+++ b/Podman Desktop/Models/ViewRouter.swift
@@ -1,0 +1,22 @@
+//
+//  ViewRouter.swift
+//  Podman Desktop
+//
+//  Created by Ashley Cui on 1/28/22.
+//
+
+import Foundation
+
+
+class ViewRouter: ObservableObject {
+    
+    @Published var currentPage: Page = .land
+    
+}
+
+enum Page {
+    case land
+    case settings
+    case machineSelect
+    case machineInit
+}

--- a/Podman Desktop/Podman_DesktopApp.swift
+++ b/Podman Desktop/Podman_DesktopApp.swift
@@ -11,9 +11,6 @@ import SwiftUI
 struct Podman_DesktopApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     init() {
-            if !UserDefaults.standard.bool(forKey: "didLaunchBefore") {
-                UserDefaults.standard.set(true, forKey: "didLaunchBefore")
-            }
     }
         
     var body: some Scene {

--- a/Podman Desktop/Views/BodyView.swift
+++ b/Podman Desktop/Views/BodyView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct BodyView: View {
-    @EnvironmentObject var machineOn: MachineOn
+    @EnvironmentObject var allMachines: AllMachines
     var body: some View {
         VStack{
         Spacer()
@@ -21,8 +21,34 @@ struct BodyView: View {
                 .padding()
             Text("To start working with containers on Podman, \nyou'll need to run the Podman service.")
                 .multilineTextAlignment(.center)
-            Toggle("Run Podman", isOn: $machineOn.isOn)
-                .toggleStyle(SwitchToggleStyle(tint: Color("toggle-on")))
+            Button {
+                allMachines.reloadAll()
+                if !allMachines.running{
+                    Task{
+                        do {
+                            try await allMachines.startActive()
+                            allMachines.reloadAll()
+
+                        }
+                    catch {print("error")} // TODO: plumb custom errors
+                    }
+                    
+                } else {
+                    Task{
+                    do {try await allMachines.stopActive()
+                        allMachines.reloadAll()
+                    }
+                    catch {print("error")} // TODO: plumb custom errors
+                    }
+                }
+            } label: {
+                Image(systemName: "power.circle.fill")
+                    .resizable()
+                    .scaledToFit()
+                    .foregroundStyle(allMachines.running ? .green : .white, allMachines.running ? .white : .purple )
+                    .frame(width: 50, height: 50)
+            }.padding(EdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0))
+            .buttonStyle(PlainButtonStyle())
             Spacer()
         }
     }

--- a/Podman Desktop/Views/ContentView.swift
+++ b/Podman Desktop/Views/ContentView.swift
@@ -10,54 +10,43 @@ import SwiftUI
 
 
 struct ContentView: View {
-    var machineOn = MachineOn()
-    @State private var settings = false
+    var allMachines = AllMachines()
+    @StateObject var viewRouter = ViewRouter()
     var body: some View {
         VStack(spacing: 0){
-            HeaderView(settings: $settings)
+            HeaderView()
                 .frame(height: 70)
-                .environmentObject(machineOn)
+                .environmentObject(allMachines)
+                .environmentObject(viewRouter)
+                .onAppear {
+                    allMachines.reloadAll()
+                }
 
-//            AnotherView()
-            if self.settings{
-                SettingsView(settings: $settings)
-                    .frame(height: 300)
-                Spacer()
-            }else{
+            switch viewRouter.currentPage {
+            case .land:
                 BodyView()
+                    .environmentObject(viewRouter)
+                    .environmentObject(allMachines)
+            case .settings:
+                SettingsView()
+                    .environmentObject(viewRouter)
+                    .environmentObject(allMachines)
+            case .machineSelect:
+                MachineSelectView()
+                    .environmentObject(viewRouter)
+                    .environmentObject(allMachines)
+            case .machineInit:
+                MachineInitView()
+                    .environmentObject(viewRouter)
+                    .environmentObject(allMachines)
             }
-//            SettingsView(settings: $settings)
-//                .frame(height: 300)
-//            MachineInitView()
             Spacer()
-//            BodyView()
-//            Spacer()
         }
         .ignoresSafeArea()
-
-//
-//        .menuStyle(BorderlessButtonMenuStyle())
         .frame(minWidth: 800, maxWidth: .infinity, minHeight: 500,  maxHeight: .infinity)
-        .environmentObject(machineOn)
     }
 }
-    
-class MachineOn: ObservableObject {
-    @Published var isOn: Bool
-    @Published var displayString: String
-    init(){
-        let machs = AllMachines()
-        let isRunning = machs.getRunning().isRunning
-        if isRunning{
-            self.isOn = true
-            self.displayString="running"
-        } else {
-            self.isOn = false
-            self.displayString="not running"
-        }
-    }
-    
-}
+
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {

--- a/Podman Desktop/Views/MachineInitView.swift
+++ b/Podman Desktop/Views/MachineInitView.swift
@@ -8,15 +8,16 @@
 import SwiftUI
 
 struct MachineInitView: View {
-    
-    @ObservedObject var newMachine = NewMachine()
+    @EnvironmentObject var viewRouter: ViewRouter
+    @EnvironmentObject var allMachines: AllMachines
+    @ObservedObject var newMachine = NewMachineInit()
     var streams = ["stable", "testing", "next"]
     @State private var vmImg = "fcos"
     @State var customVM = false
     @State var customIgn = false
     @State private var ignFile = ""
     @State var imgFile = ""
-    
+
     var memoryToInt: Binding<Double>{
             Binding<Double>(get: {
                 //returns the score as a Double
@@ -160,15 +161,17 @@ struct MachineInitView: View {
             }
             HStack{
                 Button("Cancel"){
-                    print("go back")
+                    viewRouter.currentPage = .machineSelect
                 }
                 Button("Submit") {
-                               // need to validate data, make sure no fields are emptyhere
+                               // TODO: need to validate data, make sure no fields are emptyhere
                     do{
                         try newMachine.create()
+                        allMachines.reloadAll()
                     } catch {
-                        print("error")
+                        print("error") // TODO: plumb custom errors
                     }
+                    viewRouter.currentPage = .machineSelect
                 }
             }
             .padding(40)

--- a/Podman Desktop/Views/MachineSelectView.swift
+++ b/Podman Desktop/Views/MachineSelectView.swift
@@ -8,20 +8,41 @@
 import SwiftUI
 
 struct MachineSelectView: View {
-    @ObservedObject var allMachines = AllMachines()
+    @EnvironmentObject var viewRouter: ViewRouter
+    @EnvironmentObject var allMachines: AllMachines
     @State private var chosenVM = ""
+
+    @State private var machineIndex = 0
+
     var body: some View {
-        Picker("VM", selection: $chosenVM){
-            ForEach(allMachines.lst, id: \.self) { item in
-                Text(item.name)
+        Group{
+        Form {
+                Picker("Select a machine", selection: $machineIndex) {
+                    ForEach(0..<allMachines.lst.count) { index in
+                        Text(self.allMachines.lst[index].name)
+                    }
+                }
+                Text(allMachines.lst[machineIndex].name)
+            }
+            HStack{
+                Button("Set Machine"){
+                    allMachines.setActiveMachine(machine: allMachines.lst[machineIndex])
+                    viewRouter.currentPage = .settings
+                }
+        Button("Cancel"){
+            viewRouter.currentPage = .settings
         }
-    }
-        Text("Selected: \(chosenVM)")
+            }
+            Button("Create new VM"){
+                viewRouter.currentPage = .machineInit
+            }
+        }
+        .frame(width: 700)
     }
 }
 
-struct MachineSelectView_Previews: PreviewProvider {
-    static var previews: some View {
-        MachineSelectView()
-    }
-}
+//struct MachineSelectView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        MachineSelectView()
+//    }
+//}

--- a/Podman Desktop/Views/MenuBar.swift
+++ b/Podman Desktop/Views/MenuBar.swift
@@ -37,8 +37,18 @@ struct MenuBar: View {
                                         .foregroundColor(.black)
                     
                                 }
-                                Toggle("", isOn: $machineOn)
-                        .toggleStyle(SwitchToggleStyle(tint: Color("toggle-on")))
+                    Button {
+                        machineOn.toggle()
+                    } label: {
+                        Image(systemName: "power.circle.fill")
+                            .resizable()
+                            .scaledToFit()
+                            .foregroundStyle(machineOn ? .green : .white, machineOn ? .white : .purple )
+                            .frame(width: 50, height: 50)
+                    }
+                    .padding(EdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0))
+                    
+                    .buttonStyle(PlainButtonStyle())
                     Spacer()
                     Button("Manage Podman"){
                       openPreferences()

--- a/Podman Desktop/Views/SettingsView.swift
+++ b/Podman Desktop/Views/SettingsView.swift
@@ -8,9 +8,8 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @ObservedObject var currMachine = DefaultMachine()
-    @Binding var settings: Bool
-    
+    @EnvironmentObject var viewRouter: ViewRouter
+    @EnvironmentObject var allMachines: AllMachines
     var body: some View {
         VStack {
             Group{
@@ -22,7 +21,7 @@ struct SettingsView: View {
                             .font(.title2)
                         Spacer()
                         Button(action: {
-                            self.settings.toggle()
+                            viewRouter.currentPage = .land
                                     }){
                                         Image(systemName: "xmark")
                                             .resizable()
@@ -37,8 +36,8 @@ struct SettingsView: View {
                     }
                     .padding(EdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20))
                 }
-                .padding(EdgeInsets(top: 54, leading: 0, bottom: 0, trailing: 0))
-                .frame(height: 100, alignment: .leading)
+
+                .frame(height: 50, alignment: .leading)
             }
             Spacer()
             Group{
@@ -55,37 +54,40 @@ struct SettingsView: View {
                 }
                 Divider()
             Spacer()
+            }
+            .frame(width: 700)
+            Group{
                 HStack{
                     Spacer()
                     VStack(alignment: .leading){
                         HStack{
                             Text("Name: ")
-                            Text(currMachine.name)
+                            Text(allMachines.activeMachine!.name)
                         }
                         HStack{
                             Text("VM Type: ")
-                            Text(currMachine.vmtype)
+                            Text(allMachines.activeMachine!.vmtype)
                         
                         }
                         HStack{
                             Text("Created: ")
-                            Text(currMachine.created)
+                            Text(allMachines.activeMachine!.created)
                         }
                     }
                     Spacer()
                     VStack(alignment: .leading){
                         HStack{
                             Text("CPUs: ")
-                            Text(String(currMachine.cpus))
+                            Text(String(allMachines.activeMachine!.cpus))
                         }
                         HStack{
                             Text("RAM: ")
-                            Text(currMachine.memory)
+                            Text(allMachines.activeMachine!.memory)
                         
                         }
                         HStack{
                             Text("Disk Size: ")
-                            Text(currMachine.disksize)
+                            Text(allMachines.activeMachine!.disksize)
                         }
                         }
                     Spacer()
@@ -93,20 +95,22 @@ struct SettingsView: View {
             }
             .frame(width: 700)
             Spacer()
+            
             Button("Use a different VM for podman machine"){
-                print("init")
+                viewRouter.currentPage = .machineSelect
             }
+            .padding(EdgeInsets(top: 20, leading: 0, bottom: 0, trailing: 0))
 
+            
             HStack{
-                Button("Visit the Podman Website"){
-                    print("init")
-                }
-                Button("Join the Podman Community"){
-                    print("init")
-                }
-                Button("Report a Problem"){
-                    print("init")
-                }
+                Link("Visit the Podman Website", destination: URL(string: "https://podman.io")!)
+                    .padding()
+                Link("Join the Podman Community", destination: URL(string: "https://podman.io/community")!)
+                    .padding()
+
+                Link("Report a Problem", destination: URL(string: "https://github.com/containers/podman-desktop/issues")!)
+                    .padding()
+
             }
         .padding()
         }


### PR DESCRIPTION
Consolidate state handling into one Environment object
Cache machines fetched from the CLI
Logic for determining which machine is active
(In this order: currently running, last running, CLI default)
Re-connect states
Clean up and make CLI functions async
Change toggle to button for better usage of bindings
Write out Error stubs (To be handled)

Signed-off-by: Ashley Cui <acui@redhat.com>