### PR TITLE
Add more previews representing various situations

### DIFF
--- a/Podman Desktop/Models/Machine.swift
+++ b/Podman Desktop/Models/Machine.swift
@@ -61,12 +61,16 @@ class AllMachines: ObservableObject{
         noMachines = false
     }
     
+    private static func listMachinesFromPodman() throws -> [Machine]  {
+        let output = try machineList()
+        let jsonData = output.1.data(using: .utf8)!
+        return try! JSONDecoder().decode([Machine].self, from: jsonData)
+    }
+    
     func loadLst(){
         var jsons = [Machine]()
         do {
-            let output = try machineList()
-            let jsonData = output.1.data(using: .utf8)!
-            jsons = try! JSONDecoder().decode([Machine].self, from: jsonData)
+            jsons = try AllMachines.listMachinesFromPodman()
         }
         catch {
             print("\(error)") // TODO: plumb custom errors

--- a/Podman Desktop/Models/Machine.swift
+++ b/Podman Desktop/Models/Machine.swift
@@ -117,8 +117,8 @@ class AllMachines: ObservableObject{
     }
 
     func loadRunning() {
-        running = activeMachine!.running
-        runningString = activeMachine!.running ? "running" : "not running"
+        running = activeMachine?.running ?? false // Should we have an extra state to represent “N/A, no machine exists”?
+        runningString = running ? "running" : "not running"
     }
     func loadActiveMachine() {
             // 1. Active machine is running

--- a/Podman Desktop/Views/BodyView.swift
+++ b/Podman Desktop/Views/BodyView.swift
@@ -56,6 +56,15 @@ struct BodyView: View {
 
 struct BodyView_Previews: PreviewProvider {
     static var previews: some View {
-        BodyView()
+        let situations: [(name: String, allMachines: AllMachines)] = [
+            ("Running", AllMachines.previewWithOneRunningMachine()),
+            ("Stopped", AllMachines.previewWithOneStoppedMachine()),
+            ("No machine", AllMachines.previewWithNoMachines()),
+        ]
+        ForEach(situations, id: \.name) { s in
+            BodyView()
+                .environmentObject(s.allMachines)
+                .previewDisplayName(s.name)
+        }
     }
 }

--- a/Podman Desktop/Views/HeaderView.swift
+++ b/Podman Desktop/Views/HeaderView.swift
@@ -94,3 +94,19 @@ struct MachineControls: View{
         .buttonStyle(PlainButtonStyle())
     }
 }
+
+struct HeaderView_Previews: PreviewProvider {
+    static var previews: some View {
+        let situations: [(name: String, allMachines: AllMachines)] = [
+            ("Running", AllMachines.previewWithOneRunningMachine()),
+            ("Stopped", AllMachines.previewWithOneStoppedMachine()),
+            ("No machine", AllMachines.previewWithNoMachines()),
+        ]
+        ForEach(situations, id: \.name) { s in
+            HeaderView()
+                .environmentObject(s.allMachines)
+                .environmentObject(ViewRouter())
+                .previewDisplayName(s.name)
+        }
+    }
+}

--- a/Podman Desktop/Views/MachineInitView.swift
+++ b/Podman Desktop/Views/MachineInitView.swift
@@ -188,6 +188,8 @@ struct MachineInitView_Previews: PreviewProvider {
         VStack {
             MachineInitView()
         }
+        .environmentObject(AllMachines.previewWithOneRunningMachine())
+        .environmentObject(ViewRouter())
     }
 }
 

--- a/Podman Desktop/Views/MachineInitView.swift
+++ b/Podman Desktop/Views/MachineInitView.swift
@@ -185,7 +185,9 @@ struct MachineInitView: View {
 
 struct MachineInitView_Previews: PreviewProvider {
     static var previews: some View {
-        MachineInitView()
+        VStack {
+            MachineInitView()
+        }
     }
 }
 

--- a/Podman Desktop/Views/MachineSelectView.swift
+++ b/Podman Desktop/Views/MachineSelectView.swift
@@ -41,8 +41,20 @@ struct MachineSelectView: View {
     }
 }
 
-//struct MachineSelectView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        MachineSelectView()
-//    }
-//}
+struct MachineSelectView_Previews: PreviewProvider {
+    static var previews: some View {
+        let situations: [(name: String, allMachines: AllMachines)] = [
+            ("Standard", AllMachines.previewWithSeveralMachines()),
+            // Currently crashes
+            // ("No machine", AllMachines.previewWithNoMachines()),
+        ]
+        ForEach(situations, id: \.name) { s in
+            VStack {
+                MachineSelectView()
+            }
+            .environmentObject(s.allMachines)
+            .environmentObject(ViewRouter())
+            .previewDisplayName(s.name)
+        }
+    }
+}

--- a/Podman Desktop/Views/SettingsView.swift
+++ b/Podman Desktop/Views/SettingsView.swift
@@ -117,9 +117,19 @@ struct SettingsView: View {
     }
 }
 
-//struct SettingsView_Previews: PreviewProvider {
-//    @Binding var settings: Bool
-//    static var previews: some View {
-//        SettingsView(settings: settings)
-//    }
-//}
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        let situations: [(name: String, allMachines: AllMachines)] = [
+            ("Running", AllMachines.previewWithOneRunningMachine()),
+            ("Stopped", AllMachines.previewWithOneStoppedMachine()),
+            // Currently crashes
+            // ("No machine", AllMachines.previewWithNoMachines()),
+        ]
+        ForEach(situations, id: \.name) { s in
+            SettingsView()
+                .environmentObject(s.allMachines)
+                .environmentObject(ViewRouter())
+                .previewDisplayName(s.name)
+        }
+    }
+}


### PR DESCRIPTION
(@ashley-cui Please use this, or not, however you want. I don’t want to interfere with any other work — frankly this PR is me procrastinating. I’m perfectly fine with dropping this, or rebasing this later when some other work lands.)

Allow using `AllMachines` with static data, instead of querying a running Podman, and use that to add more previews of the various views; I was using this to see what #6 does and looks like, in various situations, so I might just as well turn it into something potentially valuable.

- Includes a fix for https://github.com/containers/podman-desktop/pull/6#discussion_r799812068 , necessary to make some of the previews possible at all.
- Some views currently crash when there are no machines (and that shows up in Xcode very horribly, with the preview panel just showing a failure with an inscrutable error message, instead of offering to start the debugger or at least logging a backtrace). I have just commented those previews out, in order not to interfere with any other work on the real code.