### PR TITLE
Update docs: switch to podman-desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# podman-desktop
+# podman-desktop-swift 
 
-podman-desktop is a graphical menu bar application for managing Podman machines.
+podman-desktop-swift has been dropped in favor of an electron based app. Please see podman-desktop for a more complete GUI.
 
-Currently, it only supports MacOS using SwiftUI.
+podman-desktop-swift was a graphical menu bar application for managing Podman machines.
 
-podman-desktop is still in its early stages, and should be treated as experimental in its current state. 
-At the current moment, it needs HEAVY editing for error handing, state wrestling and window management,
-as well as general organization.
+It only supports MacOS using SwiftUI.
+
+podman-desktop-swift was still in its early stages, and was be treated as experimental in that state. 


### PR DESCRIPTION
No longer on working on podman-desktop-swift. Using electron based podman-desktop instead

Signed-off-by: Ashley Cui <acui@redhat.com>